### PR TITLE
Fix mismatched check/install for jdk 11 and 17, consistent sudo macro

### DIFF
--- a/install-ghidra.sh
+++ b/install-ghidra.sh
@@ -11,13 +11,13 @@ test -z "$WGET" && { echo Error: wget not found ; exit 1 ; }
 
 function install_java {
   echo "Checking to see if Java is installed..."
-  PKG_OK=$(dpkg-query -W --showformat='${Status}\n' openjdk-11-jdk | grep "install ok installed")
+  PKG_OK=$(dpkg-query -W --showformat='${Status}\n' openjdk-17-jdk | grep "install ok installed")
 
   if [ "" == "$PKG_OK" ]; then
     echo "Downloading JDK .. please wait..."
-    sudo add-apt-repository ppa:openjdk-r/ppa -y > /dev/null 2>&1
-    sudo apt update
-    sudo apt install openjdk-17-jdk -y
+    $SUDO add-apt-repository ppa:openjdk-r/ppa -y > /dev/null 2>&1
+    $SUDO apt update
+    $SUDO apt install openjdk-17-jdk -y
   fi
 }
 


### PR DESCRIPTION
Fixes:
- Checked jdk version is 11, installed is 17.
- inconsistent use of `sudo` and `$SUDO` breaks usage in most containers